### PR TITLE
Implement offline translation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,42 @@
 # PocketLang
-This is the start of the PocketLang, or PLang journey.
-This is where we begin programming the offline application of a Pocket Language Translator, made possible thanks to quantized Artificial Intelligence.
 
-## Developed by Temirkulov & Others.
+PocketLang is a simple offline language translation tool. It uses
+pre-trained machine translation models from HuggingFace that can be
+stored locally for completely offline usage.
+
+## Installation
+
+1. Install the required Python packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Download a translation model from HuggingFace and place it somewhere
+   on your system. For example, to translate from English to German you
+   can download `Helsinki-NLP/opus-mt-en-de`:
+   ```bash
+   transformers-cli download Helsinki-NLP/opus-mt-en-de
+   ```
+   After downloading, you can copy the model directory to your offline
+   machine.
+
+## Usage
+
+Run the CLI with the path to the local model directory and the text you
+want to translate:
+
+```bash
+python -m pocketlang.cli /path/to/model "Hello, world"
+```
+
+The translated text will be printed to the terminal.
+
+## Library Usage
+
+PocketLang can also be used as a Python library:
+
+```python
+from pocketlang import Translator
+
+translator = Translator('/path/to/model')
+print(translator.translate('Hello, world'))
+```

--- a/pocketlang/__init__.py
+++ b/pocketlang/__init__.py
@@ -1,0 +1,5 @@
+"""PocketLang - Offline translation library."""
+
+from .translator import Translator
+
+__all__ = ["Translator"]

--- a/pocketlang/cli.py
+++ b/pocketlang/cli.py
@@ -1,0 +1,23 @@
+"""Command line interface for PocketLang translator."""
+
+import argparse
+
+from .translator import Translator
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Offline translator using pretrained models")
+    parser.add_argument("model", help="Path to the local translation model directory")
+    parser.add_argument("text", help="Text to translate")
+    parser.add_argument(
+        "--max-length", type=int, default=512, help="Maximum translation length"
+    )
+    args = parser.parse_args()
+
+    translator = Translator(args.model)
+    translation = translator.translate(args.text, max_length=args.max_length)
+    print(translation)
+
+
+if __name__ == "__main__":
+    main()

--- a/pocketlang/translator.py
+++ b/pocketlang/translator.py
@@ -1,0 +1,25 @@
+"""Simple offline translation utilities."""
+
+from pathlib import Path
+from typing import Optional
+
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+
+
+class Translator:
+    """Load a HuggingFace translation model for offline use."""
+
+    def __init__(self, model_dir: str):
+        self.model_dir = Path(model_dir)
+        if not self.model_dir.exists():
+            raise FileNotFoundError(
+                f"Model directory '{self.model_dir}' does not exist."
+            )
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_dir)
+        self.model = AutoModelForSeq2SeqLM.from_pretrained(self.model_dir)
+
+    def translate(self, text: str, max_length: Optional[int] = 512) -> str:
+        """Translate a single piece of text."""
+        inputs = self.tokenizer(text, return_tensors="pt")
+        outputs = self.model.generate(**inputs, max_length=max_length)
+        return self.tokenizer.decode(outputs[0], skip_special_tokens=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+transformers==4.40.1
+torch


### PR DESCRIPTION
## Summary
- add a small `pocketlang` package
- implement a Translator class and command line interface
- update README with install and usage instructions
- add requirements.txt for dependencies

## Testing
- `python -m pocketlang.cli dummy_model "Hello"` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68413afa3a5883219dffff04c3d7d659